### PR TITLE
Fixed LT terminals

### DIFF
--- a/includes/abstracts/class-wc-estonian-shipping-method-omniva.php
+++ b/includes/abstracts/class-wc-estonian-shipping-method-omniva.php
@@ -39,6 +39,10 @@ abstract class WC_Estonian_Shipping_Method_Omniva extends WC_Estonian_Shipping_M
 
 		foreach( $terminals_json as $key => $location ) {
 			if( $location->A0_NAME == $filter_country && $location->TYPE == $filter_type ) {
+				$cityKey = 'A2_NAME';
+				if($filter_country == 'LT') {
+					$cityKey = 'A1_NAME';
+				}
 				$locations[] = (object) array(
 					'place_id'   => $location->ZIP,
 					'zipcode'    => $location->ZIP,


### PR DESCRIPTION
Hello. 

I know this is not the perfect solution but there is a problem when using Lithuanian Omnival terminals - it's grouping not by the city name but by the terminal name so each terminal gets a group.

This should be some where in the settings.

Before:
![before](https://cloud.githubusercontent.com/assets/11888315/21081862/5eeaab80-bfd8-11e6-9830-0818da5ab71b.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/11888315/21081864/614514ba-bfd8-11e6-906d-9677c53e7e79.jpg)



Thanks for your hard work!!!
