### PR TITLE
nested ternary operator fix for PHP 7.4

### DIFF
--- a/includes/abstracts/class-wc-estonian-shipping-method-terminals.php
+++ b/includes/abstracts/class-wc-estonian-shipping-method-terminals.php
@@ -696,7 +696,7 @@ abstract class WC_Estonian_Shipping_Method_Terminals extends WC_Estonian_Shippin
 			$a_number = $this->get_city_order_number( $a->city );
 			$b_number = $this->get_city_order_number( $b->city );
 
-			return ( $a_number == $b_number ) ? 0 : ( $a_number > $b_number ) ? -1 : 1;
+			return ( ( $a_number == $b_number ) ? 0 : ( $a_number > $b_number ) ) ? -1 : 1;
 		}
 	}
 


### PR DESCRIPTION
https://www.php.net/manual/en/migration74.deprecated.php
In PHP 7.4 nested ternary operators must use explicit parenthesis. 
This is currently giving off a warning in the plugin at:
wp-content/plugins/estonian-shipping-methods-for-woocommerce/includes/abstracts/class-wc-estonian-shipping-method-terminals.php:699