### PR TITLE
Php8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,131 @@
-## Estonian Shipping Methods for WooCommerce ##
+# Estonian Shipping Methods for WooCommerce
 
-- Contributors: @RistoNiinemets
-- Tags: WooCommerce, shipping method, Estonia, smartpost, dpd, pakiautomaat, courier, omniva
-- Requires at least: 4.1
-- Tested up to: 6.1.1
-- Stable tag: 1.7.2
-- License: GPLv2 or later
+Extends WooCommerce with most commonly used Estonian shipping methods. All in one.
 
+*   DPD package shops (Estonia, Latvia, Lithuania)
+*   Omniva parcel terminals (Estonia, Latvia, Lithuania)
+*   Omniva post offices (Estonia)
+*   SmartPOST parcel terminals (Estonia, Finland, Latvia, Lithuania)
+*   SmartPOST courier
+*   Collect.net packrobots (Estonia)
 
-## Shipping Methods ##
+Supports WPML for multilingual sites. Current translations:
 
-- DPD package shops (Estonia, Latvia, Lithuania)
-- Omniva parcel terminals (Estonia, Latvia, Lithuania)
-- Omniva post offices (Estonia)
-- SmartPOST parcel terminals (Estonia, Finland, Latvia, Lithuania)
-- SmartPOST courier
-- Collect.net packrobots (Estonia)
+*   English (props @ristoniinemets)
+*   Estonian (props @ristoniinemets)
+*   Lithuanian (props @DomasWEB)
+*   Russian (props @avramchuk)
 
+Code is maintained and developed at Github. Contributions and discussions are very welcome at [Github](https://github.com/KonektOU/estonian-shipping-methods-for-woocommerce)
 
-## Multilingual (WPML support) ##
+## Installation
 
-- English (props @ristoniinemets)
-- Estonian (props @ristoniinemets)
-- Lithuanian (props @DomasWEB)
-- Russian (props @avramchuk)
+1. Upload `estonian-shipping-methods-for-woocommerce` folder to the `/wp-content/plugins/` directory
+2. Activate the plugin through the 'Plugins' menu in WordPress
+3. Go to WooCommerce - Settings
+4. Shipping Methods will be available to be configured in "Shipping" settings
+
+## Screenshots
+
+1. Example of Itella SmartPOST shipping method
+2. WooCommerce Checkout page
+
+## Frequently Asked Questions
+
+= How to display customer selected terminal in custom locations? =
+Since version 1.5.1 we have added an action that you could add to your code:
+`do_action( 'wc_estonian_shipping_method_show_terminal', $order_id );`
+
+## Changelog
+
+### 1.7.3
+* Added PHP8-compatibility
+
+### 1.7.2
+* Fix Smartpost location not shown
+
+### 1.7.1
+* Add support for older orders locations (SmartPost)
+
+### 1.7
+* Use DPD API for pickup locations instead of soon-to-be-deprecated FTP json
+* Use Smartpost API for pickup locations
+* Add Smartpost Latvia
+* Add Smartpost Lithuania
+
+### 1.6.2
+* Compatibility with WooCommerce CRUD, High-Performance order storage (COT)
+
+### 1.6.0
+* Relocate terminal methods hooks for compatibility with other plugins
+* Add version tag to templates, clean up templates
+* Removed use of deprecated WC property
+
+### 1.5.9
+* Change DPD terminals source URL
+
+### 1.5.8
+* Add PHP 7.4 compatbility (thanks to @lemmeV)
+
+### 1.5.7
+* Fix admin order preview with SmartPOST courier
+* Tweak Collect.net API relationships
+
+### 1.5.6
+* Fix compatibility with older versions of WooCommerce. Previous version introduced conflict.
+
+### 1.5.5
+* Tweak free shipping amount to take discounted prices into account
+
+### 1.5.4
+* Fix Collect.net availability in other countries than Estonia (should not be available)
+
+### 1.5.3
+* Fix dropdown selection text (mixed labels)
+
+### 1.5.2
+* WooCommerce 3.3 compatibility and terminal information in admin order preview
+
+### 1.5.1
+* Compatibility with WooCommerce PDF Invoices & Packing Slips plugin
+* Added custom action that developers can hook into to show the customer selected terminal
+
+### 1.5
+* Compatibility with servers that have "allow_url_fopen" PHP configration turned off.
+* Extra option whether each shipping method allows free shipping via coupons.
+
+### 1.4.2
+* Fix notice with Collect.net AGAIN
+
+### 1.4.1
+* Fix: Sometimes terminals were not fetched and shown in customers email
+
+### 1.4
+* Fix notice with Collect.net while it’s not being used
+* Make phone number country code validation available for all methods
+* Use phone number country code validation for DPD package shops
+
+### 1.3.2
+* Create collect.net session only on administration interface
+
+### 1.3.1
+* Compatibility with WooCommerce 3.0.x
+
+### 1.3
+* Added Collect.net packrobots
+* Cleaned up code
+
+### 1.2.1
+* Added Lithuanian (thanks to @DomasWEB) and Russian translations (thanks to @avramchuk)
+
+### 1.2
+* Fixed mixed up translations in Estonian
+* Omniva Latvia, Lithuania: City name fix (thanks to @DomasWEB)
+* Latvia, Lithuania: Added cities by population for "Bigger cities first, then alphabetically the rest" option to work
+
+### 1.1
+* Added shipping methods to readme
+* Added DPD package shops for Estonia, Latvia, Lithuania
+
+### 1.0
+* Release

--- a/estonian-shipping-methods-for-woocommerce.php
+++ b/estonian-shipping-methods-for-woocommerce.php
@@ -11,7 +11,7 @@
  * Text Domain: wc-estonian-shipping-methods
  * Domain Path: /languages
  * WC requires at least: 3.3
- * WC tested up to: 7.5.1
+ * WC tested up to: 10.7.0
  *
  * @package Estonian_Shipping_Methods_For_WooCommerce
  */

--- a/estonian-shipping-methods-for-woocommerce.php
+++ b/estonian-shipping-methods-for-woocommerce.php
@@ -80,7 +80,7 @@ class Estonian_Shipping_Methods_For_WooCommerce {
 	 */
 	public function __construct() {
 		// Load plugin functionality when others have loaded.
-		add_action( 'init', array( $this, 'plugins_loaded' ) );
+		add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ) );
 	}
 
 	/**
@@ -93,9 +93,13 @@ class Estonian_Shipping_Methods_For_WooCommerce {
 			return false;
 		}
 
-		// Load functionality, translations.
+		// Load functionality.
 		$this->includes();
-		$this->load_translations();
+
+		// Translations and terminal class instantiation are deferred to `init`
+		// (WP 6.7+ disallows triggering translation loading before `init`).
+		add_action( 'init', array( $this, 'load_translations' ) );
+		add_action( 'init', array( $this, 'add_terminals_hooks' ) );
 
 		// Shipping.
 		add_action( 'woocommerce_shipping_init', array( $this, 'shipping_init' ) );
@@ -108,8 +112,6 @@ class Estonian_Shipping_Methods_For_WooCommerce {
 		add_filter( 'woocommerce_locate_core_template', array( $this, 'locate_template' ), 20, 3 );
 
 		add_action( 'before_woocommerce_init', array( $this, 'declare_wc_cot_compatibility' ) );
-
-		$this->add_terminals_hooks();
 	}
 
 	/**

--- a/estonian-shipping-methods-for-woocommerce.php
+++ b/estonian-shipping-methods-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Estonian Shipping Methods for WooCommerce
  * Plugin URI: https://github.com/KonektOU/estonian-shipping-methods-for-woocommerce
  * Description: Extends WooCommerce with most commonly used Estonian shipping methods.
- * Version: 1.7.2
+ * Version: 1.7.3
  * Author: Konekt OÜ
  * Author URI: https://www.konekt.ee
  * Developer: Risto Niinemets
@@ -80,7 +80,7 @@ class Estonian_Shipping_Methods_For_WooCommerce {
 	 */
 	public function __construct() {
 		// Load plugin functionality when others have loaded.
-		add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ) );
+		add_action( 'init', array( $this, 'plugins_loaded' ) );
 	}
 
 	/**

--- a/includes/abstracts/class-wc-estonian-shipping-method-terminals.php
+++ b/includes/abstracts/class-wc-estonian-shipping-method-terminals.php
@@ -30,6 +30,16 @@ abstract class WC_Estonian_Shipping_Method_Terminals extends WC_Estonian_Shippin
 	public $terminals = array();
 
 	/**
+	 * @var string
+	 */
+	public $field_name = '';
+
+	/**
+	 * @var string
+	 */
+	public $i18n_selected_terminal = '';
+
+	/**
 	 * __construct function.
 	 *
 	 * @access public

--- a/includes/abstracts/class-wc-estonian-shipping-method-terminals.php
+++ b/includes/abstracts/class-wc-estonian-shipping-method-terminals.php
@@ -32,6 +32,11 @@ abstract class WC_Estonian_Shipping_Method_Terminals extends WC_Estonian_Shippin
 	/**
 	 * @var string
 	 */
+	public $name_format = '';
+
+	/**
+	 * @var string
+	 */
 	public $field_name = '';
 
 	/**

--- a/includes/abstracts/class-wc-estonian-shipping-method.php
+++ b/includes/abstracts/class-wc-estonian-shipping-method.php
@@ -18,6 +18,21 @@ abstract class WC_Estonian_Shipping_Method extends WC_Shipping_Method {
 	public $country = 'EE';
 
 	/**
+	 * @var mixed
+	 */
+	public $shipping_price;
+
+	/**
+	 * @var mixed
+	 */
+	public $free_shipping_amount;
+
+	/**
+	 * @var bool
+	 */
+	public $enable_free_shipping_coupons;
+
+	/**
 	 * __construct function.
 	 *
 	 * @access public

--- a/includes/methods/class-wc-estonian-shipping-method-collect-net.php
+++ b/includes/methods/class-wc-estonian-shipping-method-collect-net.php
@@ -42,6 +42,11 @@ class WC_Estonian_Shipping_Method_Collect_Net extends WC_Estonian_Shipping_Metho
 	private $skip_auth_token = false;
 
 	/**
+	 * @var string
+	 */
+	public $auth_error_notice = '';
+
+	/**
 	 * Class constructor
 	 */
 	public function __construct() {

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: konektou, ristoniinemets
 Tags: WooCommerce, shipping method, Estonia, smartpost, dpd, pakiautomaat, courier, omniva
 Requires at least: 4.1
-Tested up to: 6.1.1
-Stable tag: 1.7.2
+Tested up to: 6.9.4
+Stable tag: 1.7.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,9 @@ Since version 1.5.1 we have added an action that you could add to your code:
 
 == Changelog ==
 
+= 1.7.3 =
+* Added PHP8-compatibility
+
 = 1.7.2 =
 * Fix Smartpost location not shown
 


### PR DESCRIPTION
- PHP8-compatibility: all used properties declared in classes
- Updated READFME.md file from readme.txt
- Fixed notification:   Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the wc-estonian-shipping-methods domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This message was added in version 6.7.0.) 